### PR TITLE
Update default docker image variable

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -78,9 +78,9 @@ variable "ecs_capacity_provider_type" {
 }
 
 variable "ecs_docker_image_url" {
-  description = "An URL to the Docker image used by the application"
+  description = "A URL to the Docker image used by the application"
   type        = string
-  default     = "toroio/martini-runtime:latest"
+  default     = "lontiplatform/martini-server-runtime:latest"
 }
 
 // Logs configuration


### PR DESCRIPTION
This PR updates the default value of the ECR Docker image variable to lontiplatform, as toroio is now deprecated and would cause issues when provisioning ECS tasks for Martini containers. 